### PR TITLE
Add design thawing index module

### DIFF
--- a/design_freezing_index/design_freezing_index_module.ipynb
+++ b/design_freezing_index/design_freezing_index_module.ipynb
@@ -38,7 +38,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d293a8749a99402bb906c61fc6705df1",
+       "model_id": "c6e6e9c68837477c83e8fe03c2f4589e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -52,7 +52,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6d76180c03574b779dc6e2c50dd4546f",
+       "model_id": "d713287c7258425a8835ae7d6c2002ad",
        "version_major": 2,
        "version_minor": 0
       },
@@ -66,7 +66,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2ad0af6fe7d949f39049054a1e51495c",
+       "model_id": "c301ac9b691e44f890bb5c5cdbb804db",
        "version_major": 2,
        "version_minor": 0
       },
@@ -80,7 +80,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "57ec7887583a45d296a42c353141b20a",
+       "model_id": "335b0b60f9bb42548e0eaf9997184964",
        "version_major": 2,
        "version_minor": 0
       },
@@ -132,11 +132,12 @@
     "        )\n",
     "        print(f\"Design Freezing Index: {result} °F-days\")\n",
     "\n",
-    "\n",
     "# Attach the change handler to the sliders\n",
     "start_year_slider.observe(handle_slider_change, names=\"value\")\n",
     "end_year_slider.observe(handle_slider_change, names=\"value\")\n",
     "n_coldest_years_slider.observe(handle_slider_change, names=\"value\")\n",
+    "\n",
+    "handle_slider_change(None)\n",
     "\n",
     "# Display the widgets with the title and initial result\n",
     "display(start_year_slider, end_year_slider, n_coldest_years_slider, output)\n",

--- a/design_thawing_index/design_thawing_index_module.ipynb
+++ b/design_thawing_index/design_thawing_index_module.ipynb
@@ -1,0 +1,180 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "36c1eefb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import ipywidgets as widgets\n",
+    "from IPython.display import display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b9541864",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Function to compute design_index\n",
+    "def compute_and_display_design_index(start_year, end_year, n_warmest_years):\n",
+    "    \n",
+    "    df_slice = df[(df[\"year\"] >= start_year) & (df[\"year\"] < end_year)]\n",
+    "    design_index = round(df_slice.sort_values(\"value\", ascending=False).iloc[0:n_warmest_years][\"value\"].mean())\n",
+    "    return design_index\n",
+    "\n",
+    "# consider grouping by model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a068e0d3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "63b4dfc7b2c44bfcab31cea8708b91e9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "IntSlider(value=2030, description='Start Year:', max=2099, min=1980)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e947c88f53f8444785f62d439d4fdcda",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "IntSlider(value=2060, description='End Year:', max=2100, min=1981)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f69b7f3f49354a8baf5eec7422f178bb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "IntSlider(value=3, description='Number of Warmest Years:', max=10, min=1, style=SliderStyle(description_width=…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2ec2eab66c3a4d2f81fa1b813b45ee37",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Load the CSV data\n",
+    "df = pd.read_csv(\n",
+    "    \"https://earthmaps.io/mmm/degree_days/thawing_index/all/65.1/-146.6?format=csv\",\n",
+    "    header=1,\n",
+    ")\n",
+    "\n",
+    "# Create interactive widgets for input\n",
+    "start_year_slider = widgets.IntSlider(\n",
+    "    value=2030, min=1980, max=2099, step=1, description=\"Start Year:\"\n",
+    ")\n",
+    "end_year_slider = widgets.IntSlider(\n",
+    "    value=2060, min=1981, max=2100, step=1, description=\"End Year:\"\n",
+    ")\n",
+    "n_warmest_years_slider = widgets.IntSlider(\n",
+    "    value=3, min=1, max=10, step=1, description=\"Number of Warmest Years:\",\n",
+    "    style={\"description_width\": \"initial\"}\n",
+    ")\n",
+    "\n",
+    "# Create an output widget for displaying the result\n",
+    "output = widgets.Output()\n",
+    "\n",
+    "# Define a function to handle widget changes\n",
+    "def handle_slider_change(change):\n",
+    "    with output:\n",
+    "        output.clear_output()\n",
+    "\n",
+    "        if (\n",
+    "            end_year_slider.value - start_year_slider.value\n",
+    "            < n_warmest_years_slider.value\n",
+    "        ):\n",
+    "            start_year_slider.value = (\n",
+    "                end_year_slider.value - n_warmest_years_slider.value\n",
+    "            )\n",
+    "            output.clear_output()\n",
+    "        result = compute_and_display_design_index(\n",
+    "            start_year_slider.value, end_year_slider.value, n_warmest_years_slider.value\n",
+    "        )\n",
+    "        print(f\"Design Thawing Index: {result} °F-days\")\n",
+    "\n",
+    "\n",
+    "# Attach the change handler to the sliders\n",
+    "start_year_slider.observe(handle_slider_change, names=\"value\")\n",
+    "end_year_slider.observe(handle_slider_change, names=\"value\")\n",
+    "n_warmest_years_slider.observe(handle_slider_change, names=\"value\")\n",
+    "\n",
+    "handle_slider_change(None)\n",
+    "\n",
+    "# Display the widgets with the title and initial result\n",
+    "display(start_year_slider, end_year_slider, n_warmest_years_slider, output)\n",
+    "initial_result = compute_and_display_design_index(\n",
+    "    start_year_slider.value, end_year_slider.value, n_warmest_years_slider.value\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be690f47",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (SNAP Environment)",
+   "language": "python",
+   "name": "snap"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds design thawing index which is functionally a twin of the design freezing index module.

Note that these two modules may be combined at some point in the future, via either a toggle selection between freeze/thaw or with just dual output.

To test this PR, try the design_thawing_index notebook and verify that the output value changes as you'd expect (bigger numbers with a further future time period). Also observe that the cell output is initialized with a result computed from the default parameters. Head over to the `design_freezing_index` notebook and observe that the same feature has been added over there.

The frost depth module has a "compute result" button, which is a little different flavor of UX. We'll retain that for now to provide some comparison for team review.

Closes #2 