### PR TITLE
Version bumps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,18 +6,18 @@ on:
       - main
   pull_request:
     branches:
-      - '*'
+      - "*"
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.11"
       - name: Install the dependencies
         run: |
           python -m pip install -r requirements.txt
@@ -26,7 +26,7 @@ jobs:
           cp README.md content
           jupyter lite build --contents content --output-dir dist
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist
 
@@ -45,5 +45,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
-        
+        uses: actions/deploy-pages@v4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 # Core modules (mandatory)
 jupyterlite-core==0.3.0
-jupyterlab~=4.1.1
-jupyterlite-pyodide-kernel
-jupyterlab-open-url-parameter
+jupyterlab~=4.1.6
+notebook~=7.1.2
+
+# Python kernel (technically optional)
+jupyterlite-pyodide-kernel==0.3.2
 
 # Python: libraries (optional)
 pandas


### PR DESCRIPTION
This PR doesn't have any content changes - it only bumps the versions for Github Actions (some were very old) and my suspicious is that these were causing modules to get stuck in some non-deterministic and non-transparent manner. These build instructions were tested in a dummy repo with the EDS content copied into it and **seem** to function and resolve the worst of the issues that we were alerted to.

**Also know that merging this to main will trigger a rebuild of the production EDS modules.** 

Monitor the "Actions" tab in this repo to verify that the build was successful (should ding in Slack too), then test the EDS modules via arcticeds.org with a clean cache. 